### PR TITLE
fix(web): "get started" button returning 404

### DIFF
--- a/apps/web/src/content/docs/index.mdx
+++ b/apps/web/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
     file: ../../assets/csmos.webp
   actions:
     - text: Get started
-      link: /docs/getting-started
+      link: /docs/introduction
       icon: right-arrow
       variant: primary
 ---


### PR DESCRIPTION
fixes #218. this was a silly mistake I left in #177.